### PR TITLE
🐛 Fix tagged union error message

### DIFF
--- a/src/decipher.gleam
+++ b/src/decipher.gleam
@@ -497,7 +497,7 @@ pub fn tagged_union(
         }
 
         Error([
-          DecodeError(expected: tags, found: string.inspect(tag), path: path),
+          DecodeError(expected: tags, found: string.inspect(kind), path: path),
         ])
       }
     }

--- a/test/decipher_test.gleam
+++ b/test/decipher_test.gleam
@@ -1,3 +1,5 @@
+import decipher
+import gleam/dynamic.{DecodeError}
 import gleeunit
 import gleeunit/should
 
@@ -5,8 +7,25 @@ pub fn main() {
   gleeunit.main()
 }
 
-// gleeunit test functions end in `_test`
-pub fn hello_world_test() {
-  1
-  |> should.equal(1)
+type Example {
+  Wibble(foo: Int)
+  Wobble(bar: String)
+}
+
+pub fn tagged_union_test() {
+  let decoder =
+    decipher.tagged_union(dynamic.element(0, dynamic.string), [
+      #("wibble", dynamic.decode1(Wibble, dynamic.element(1, dynamic.int))),
+      #("wobble", dynamic.decode1(Wobble, dynamic.element(1, dynamic.string))),
+    ])
+
+  dynamic.from(#("wobble", "bar"))
+  |> decoder
+  |> should.be_ok
+  |> should.equal(Wobble(bar: "bar"))
+
+  dynamic.from(#("jelly"))
+  |> decoder
+  |> should.be_error
+  |> should.equal([DecodeError("\"wibble\" | \"wobble\"", "\"jelly\"", [])])
 }


### PR DESCRIPTION
DecodeError’s `actual` was always `"//fn(a) { ... }"`.